### PR TITLE
fix issues when building with mingw and msys

### DIFF
--- a/src/base/util.h
+++ b/src/base/util.h
@@ -52,7 +52,7 @@
   void operator=(const TypeName&)
 
 // Starting with Visual C++ 2005, WinNT.h includes ARRAYSIZE.
-#if !defined(_MSC_VER) || _MSC_VER < 1400
+#ifndef ARRAYSIZE
 #define ARRAYSIZE(a) \
   ((sizeof(a) / sizeof(*(a))) / \
    static_cast<size_t>(!(sizeof(a) % sizeof(*(a)))))

--- a/src/windows/port.h
+++ b/src/windows/port.h
@@ -69,7 +69,10 @@
 #endif
 
 /* file I/O */
-#define PATH_MAX 1024
+#ifndef PATH_MAX
+#define PATH_MAX 4096
+#endif
+
 #define access  _access
 #define getcwd  _getcwd
 #define open    _open


### PR DESCRIPTION
With these changes you can compile ctemplate almost without any warnings on windows with mingw32 and msys.
When build for x86_64 you have to change the prefix of PRIdS, PRIuS and PRIxS in src/config.h to I64. As this file is generated by configure the correct place to fix this is m4/compiler_characteristics.m4, but I dont know how to check for a mingw build in m4...
