### PR TITLE
Fix to build with python2 by default

### DIFF
--- a/src/htmlparser/generate_fsm.py
+++ b/src/htmlparser/generate_fsm.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #
 # Copyright (c) 2008, Google Inc.
 # All rights reserved.


### PR DESCRIPTION
I used python2.7 first, however after looking through issue #104 and the python2.patch I switched using python2 instead because python2 seems to be more generic. Booth work well though.