### PR TITLE
Switch to Python 3

### DIFF
--- a/src/htmlparser/fsm_config.py
+++ b/src/htmlparser/fsm_config.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-#
 # Copyright (c) 2008, Google Inc.
 # All rights reserved.
 #

--- a/src/htmlparser/generate_fsm.py
+++ b/src/htmlparser/generate_fsm.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Copyright (c) 2008, Google Inc.
 # All rights reserved.
@@ -282,7 +282,8 @@ class FSMGenerateC(FSMGenerateAbstract):
     for state in self._config.states:
       transition_row = []
       for c in range(0, 255):
-        transition_row.append('    /* %06s */ %s' % (repr(chr(c)),
+        ch_repr = str(repr(chr(c)).encode("ASCII", "backslashreplace"), "ASCII")
+        transition_row.append('    /* %06s */ %s' % (ch_repr,
                                                      state_table[state][c]))
 
       out.append(self._CreateStructList('%stransition_row_%s' %

--- a/src/tests/generate_fsm_test.sh
+++ b/src/tests/generate_fsm_test.sh
@@ -48,8 +48,8 @@ GENERATE_FSM="$TOOLS_DIR/generate_fsm.py"
 EXPECTED="`cat $OUTPUT_FILE`"
 if [ -z "$EXPECTED" ]; then die "Error reading $OUTPUT_FILE"; fi
 
-# Let's make sure the script works with python2.2 and above
-for PYTHON in "" "python2.2" "python2.3" "python2.4" "python2.5" "python2.6"; do
+# Let's make sure the script works with python3.5 and above
+for PYTHON in "" "python3.5" "python3.6" "python3.7" "python3.8" "python3.9"; do
   # Skip the versions of python that are not installed.
   if [ -n "$PYTHON" ]; then
     $PYTHON -h >/dev/null 2>/dev/null || continue


### PR DESCRIPTION
Time to switch unconditionally to Python 3, as Python 2 is EOL by the beginning of 2020.

This includes a mandatory fix to avoid generating broken C sources.