### PR TITLE
C++20 / gcc10 fix: remove hint, removed typedef

### DIFF
--- a/src/base/arena-inl.h
+++ b/src/base/arena-inl.h
@@ -93,8 +93,7 @@ template <class T, class C> class ArenaAllocator {
   ArenaAllocator(C* arena) : arena_(arena) { }  // NOLINT
   ~ArenaAllocator() { }
 
-  pointer allocate(size_type n,
-                   std::allocator<void>::const_pointer /*hint*/ = 0) {
+  pointer allocate(size_type n) {
     assert(arena_ && "No arena to allocate from!");
     return reinterpret_cast<T*>(arena_->AllocAligned(n * sizeof(T),
                                                      kAlignment));


### PR DESCRIPTION
C++17 deprecated, and C++20 fully removed, the std::allocator<T>::const_pointer typedef (https://en.cppreference.com/w/cpp/memory/allocator). So gcc10 fails to compile this file.

The selected fix was to completely remove the hint argument because (a) it was ignored anyway, and (b) std::allocator's allocate() function also chose to remove its hint argument in C++20 (https://en.cppreference.com/w/cpp/memory/allocator/allocate).