### PR TITLE
Simplify and cleanup Markdown formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-Welcome to the C++ CTemplate system!
-====================================
+# Welcome to the C++ CTemplate system!
 
 This library provides an easy to use and lightning fast text templating system
 to use with C++ programs.
@@ -8,8 +7,7 @@ It was originally called Google Templates, due to its origin as the template
 system used for Google search result pages. Now it has a more general name
 matching its community-owned nature.
 
-Documentation
--------------
+## Documentation
 
 Refer to the [Project
 Documentation](<https://htmlpreview.github.io/?https://github.com/OlafvdSpek/ctemplate/blob/master/doc/index.html>)
@@ -20,8 +18,7 @@ There is also a
 and
 [Examples](<https://htmlpreview.github.io/?https://raw.githubusercontent.com/OlafvdSpek/ctemplate/master/doc/example.html>).
 
-Compiling
----------
+## Compiling
 
 To compile test applications with these classes, run `./autogen.sh && ./configure` followed by
 `make` on unixoid platforms like Linux or MacOSX.
@@ -37,8 +34,7 @@ Windows under both VC++7 and VC++8.
 There are a few Windows-specific details; see README.windows for more
 information.
 
-CTemplate and Threads
----------------------
+## CTemplate and Threads
 
 The ctemplate library has thread support, so it works properly in a threaded
 environment.
@@ -48,20 +44,18 @@ add `-pthread` (or, on some systems, `-pthreads`, and on others, `-lpthread`) to
 get the library to compile. If you leave out the `-pthread`, you'll see errors
 like this:
 
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+```
 symbol lookup error: /usr/local/lib/libctemplate.so.0: undefined symbol: pthread_rwlock_init
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+```
 
-If your code isn't multi-threaded, you can instead use the ctemplate\_nothread
-library: `-lctemplate_nothreads`
+If your code isn't multi-threaded, you can instead use the `ctemplate_nothreads`
+library: `-lctemplate_nothreads`.
 
-To summarize, there are two ways to link in ctemlpate in non-threaded
+To summarize, there are two ways to link in ctemplate in non-threaded
 applications. For instance:
 
-1.  Thread safe build:`gcc -o my_app my_app.o -lctemplate -pthread`
+1.  Thread safe build: `gcc -o my_app my_app.o -lctemplate -pthread`
 
-2.  Unthreaded code:`gcc -o my_app my_app.o -lctemplate_nothreads`
+2.  Unthreaded code: `gcc -o my_app my_app.o -lctemplate_nothreads`
 
 If your application uses threads, you should use form (1).
-
-


### PR DESCRIPTION
Replace underlines with heading prefixes: it's cleaner.
Fix comment block format.
Add space between text and commands.
Minor spelling fix.