### PR TITLE
Avoid implicit T*-to-bool conversion in template_unittest.cc

### DIFF
--- a/src/tests/template_unittest.cc
+++ b/src/tests/template_unittest.cc
@@ -291,7 +291,7 @@ class EmphasizeTemplateModifier : public ctemplate::TemplateModifier {
 
   bool MightModify(const PerExpandData* per_expand_data,
                    const string& arg) const {
-    return strstr(arg.c_str(), match_.c_str());
+    return strstr(arg.c_str(), match_.c_str()) != NULL;
   }
 
   void Modify(const char* in, size_t inlen,


### PR DESCRIPTION
No functional change, but this avoids relying on C++'s implicit conversion from `char*` to `bool`, preferring explicit comparison against NULL. This is the only place in ctemplate that currently relies on implicit conversion.

See my blog post ["What breaks without implicit `T*`-to-`bool` conversion?"](https://quuxplusone.github.io/blog/2025/10/05/pointer-to-bool-conversion/) (2025-10-05).