### PR TITLE
Linter: Fix all -Wsuggest-override warnings

### DIFF
--- a/src/base/arena.h
+++ b/src/base/arena.h
@@ -493,16 +493,16 @@ class CTEMPLATE_DLL_DECL UnsafeArena : public BaseArena {
   char* AllocWithHandle(const size_t size, Handle* handle) {
     return reinterpret_cast<char*>(GetMemoryWithHandle(size, handle));
   }
-  virtual char* SlowAlloc(size_t size) {  // "slow" 'cause it's virtual
+  char* SlowAlloc(size_t size) override {  // "slow" 'cause it's virtual
     return Alloc(size);
   }
-  virtual void SlowFree(void* memory, size_t size) {  // "slow" 'cause it's virt
+  void SlowFree(void* memory, size_t size) override {  // "slow" 'cause it's virt
     Free(memory, size);
   }
-  virtual char* SlowRealloc(char* memory, size_t old_size, size_t new_size) {
+  char* SlowRealloc(char* memory, size_t old_size, size_t new_size) override {
     return Realloc(memory, old_size, new_size);
   }
-  virtual char* SlowAllocWithHandle(const size_t size, Handle* handle) {
+  char* SlowAllocWithHandle(const size_t size, Handle* handle) override {
     return AllocWithHandle(size, handle);
   }
 
@@ -580,7 +580,7 @@ class CTEMPLATE_DLL_DECL SafeArena : public BaseArena {
   SafeArena(char* first_block, const size_t block_size)
     : BaseArena(first_block, block_size, false) { }
 
-  virtual void Reset() LOCKS_EXCLUDED(mutex_) {
+  void Reset() override LOCKS_EXCLUDED(mutex_) {
     MutexLock lock(&mutex_);      // in case two threads Reset() at same time
     BaseArena::Reset();
   }
@@ -615,16 +615,16 @@ class CTEMPLATE_DLL_DECL SafeArena : public BaseArena {
     MutexLock lock(&mutex_);
     return reinterpret_cast<char*>(GetMemoryWithHandle(size, handle));
   }
-  virtual char* SlowAlloc(size_t size) {  // "slow" 'cause it's virtual
+  char* SlowAlloc(size_t size) override {  // "slow" 'cause it's virtual
     return Alloc(size);
   }
-  virtual void SlowFree(void* memory, size_t size) {  // "slow" 'cause it's virt
+  void SlowFree(void* memory, size_t size) override {  // "slow" 'cause it's virt
     Free(memory, size);
   }
-  virtual char* SlowRealloc(char* memory, size_t old_size, size_t new_size) {
+  char* SlowRealloc(char* memory, size_t old_size, size_t new_size) override {
     return Realloc(memory, old_size, new_size);
   }
-  virtual char* SlowAllocWithHandle(const size_t size, Handle* handle) {
+  char* SlowAllocWithHandle(const size_t size, Handle* handle) override {
     return AllocWithHandle(size, handle);
   }
 

--- a/src/ctemplate/template_annotator.h.in
+++ b/src/ctemplate/template_annotator.h.in
@@ -114,16 +114,16 @@ class @ac_windows_dllexport@ TemplateAnnotator {
 class @ac_windows_dllexport@ TextTemplateAnnotator : public TemplateAnnotator {
  public:
   TextTemplateAnnotator() { }
-  virtual void EmitOpenInclude(ExpandEmitter* emitter, const std::string& value);
-  virtual void EmitCloseInclude(ExpandEmitter* emitter);
-  virtual void EmitOpenFile(ExpandEmitter* emitter, const std::string& value);
-  virtual void EmitCloseFile(ExpandEmitter* emitter);
-  virtual void EmitOpenSection(ExpandEmitter* emitter, const std::string& value);
-  virtual void EmitCloseSection(ExpandEmitter* emitter);
-  virtual void EmitOpenVariable(ExpandEmitter* emitter, const std::string& value);
-  virtual void EmitCloseVariable(ExpandEmitter* emitter);
-  virtual void EmitFileIsMissing(ExpandEmitter* emitter,
-                                 const std::string& value);
+  void EmitOpenInclude(ExpandEmitter* emitter, const std::string& value) override;
+  void EmitCloseInclude(ExpandEmitter* emitter) override;
+  void EmitOpenFile(ExpandEmitter* emitter, const std::string& value) override;
+  void EmitCloseFile(ExpandEmitter* emitter) override;
+  void EmitOpenSection(ExpandEmitter* emitter, const std::string& value) override;
+  void EmitCloseSection(ExpandEmitter* emitter) override;
+  void EmitOpenVariable(ExpandEmitter* emitter, const std::string& value) override;
+  void EmitCloseVariable(ExpandEmitter* emitter) override;
+  void EmitFileIsMissing(ExpandEmitter* emitter,
+                                 const std::string& value) override;
 
  private:
   // Can't invoke copy constructor or assignment operator

--- a/src/ctemplate/template_dictionary.h.in
+++ b/src/ctemplate/template_dictionary.h.in
@@ -212,7 +212,7 @@ class @ac_windows_dllexport@ TemplateDictionary : public TemplateDictionaryInter
   // Dump goes to stdout/stderr, while DumpToString goes to the given string.
   // 'indent' is how much to indent each line of the output.
   void Dump(int indent=0) const;
-  virtual void DumpToString(std::string* out, int indent=0) const;
+  void DumpToString(std::string* out, int indent=0) const override;
 
 
   // --- DEPRECATED ESCAPING FUNCTIONALITY
@@ -341,14 +341,14 @@ class @ac_windows_dllexport@ TemplateDictionary : public TemplateDictionaryInter
 
   // How Template::Expand() and its children access the template-dictionary.
   // These fill the API required by TemplateDictionaryInterface.
-  virtual TemplateString GetValue(const TemplateString& variable) const;
-  virtual bool IsHiddenSection(const TemplateString& name) const;
-  virtual bool IsUnhiddenSection(const TemplateString& name) const {
+  TemplateString GetValue(const TemplateString& variable) const override;
+  bool IsHiddenSection(const TemplateString& name) const override;
+  bool IsUnhiddenSection(const TemplateString& name) const override {
     return !IsHiddenSection(name);
   }
-  virtual bool IsHiddenTemplate(const TemplateString& name) const;
-  virtual const char* GetIncludeTemplateName(
-      const TemplateString& variable, int dictnum) const;
+  bool IsHiddenTemplate(const TemplateString& name) const override;
+  const char* GetIncludeTemplateName(
+      const TemplateString& variable, int dictnum) const override;
 
   // Determine whether there's anything set in this dictionary
   bool Empty() const;
@@ -372,8 +372,8 @@ class @ac_windows_dllexport@ TemplateDictionary : public TemplateDictionaryInter
   //   This is SectionIterator exactly, just with a different name to
   //   self-document the fact the value applies to a template include.
   // Caller frees return value.
-  virtual TemplateDictionaryInterface::Iterator* CreateTemplateIterator(
-      const TemplateString& section_name) const;
+  TemplateDictionaryInterface::Iterator* CreateTemplateIterator(
+      const TemplateString& section_name) const override;
 
   // CreateSectionIterator
   //   Factory method implementation that constructs a iterator representing the
@@ -381,8 +381,8 @@ class @ac_windows_dllexport@ TemplateDictionary : public TemplateDictionaryInter
   //   implementation checks the local dictionary itself, not the template-wide
   //   dictionary or the global dictionary.
   // Caller frees return value.
-  virtual TemplateDictionaryInterface::Iterator* CreateSectionIterator(
-      const TemplateString& section_name) const;
+  TemplateDictionaryInterface::Iterator* CreateSectionIterator(
+      const TemplateString& section_name) const override;
 
   // TemplateDictionary-specific implementation of dictionary iterators.
   template <typename T>   // T is *TemplateDictionary::const_iterator
@@ -391,9 +391,9 @@ class @ac_windows_dllexport@ TemplateDictionary : public TemplateDictionaryInter
     friend class TemplateDictionary;
     Iterator(T begin, T end) : begin_(begin), end_(end) { }
    public:
-    virtual ~Iterator() { }
-    virtual bool HasNext() const;
-    virtual const TemplateDictionaryInterface& Next();
+    ~Iterator() override { }
+    bool HasNext() const override;
+    const TemplateDictionaryInterface& Next() override;
    private:
     T begin_;
     const T end_;

--- a/src/ctemplate/template_emitter.h.in
+++ b/src/ctemplate/template_emitter.h.in
@@ -59,10 +59,10 @@ class @ac_windows_dllexport@ StringEmitter : public ExpandEmitter {
   std::string* const outbuf_;
  public:
   StringEmitter(std::string* outbuf) : outbuf_(outbuf) {}
-  virtual void Emit(char c) { *outbuf_ += c; }
-  virtual void Emit(const std::string& s) { *outbuf_ += s; }
-  virtual void Emit(const char* s) { *outbuf_ += s; }
-  virtual void Emit(const char* s, size_t slen) { outbuf_->append(s, slen); }
+  void Emit(char c) override { *outbuf_ += c; }
+  void Emit(const std::string& s) override { *outbuf_ += s; }
+  void Emit(const char* s) override { *outbuf_ += s; }
+  void Emit(const char* s, size_t slen) override { outbuf_->append(s, slen); }
 };
 
 }

--- a/src/ctemplate/template_modifiers.h.in
+++ b/src/ctemplate/template_modifiers.h.in
@@ -76,9 +76,9 @@ class Template;
 
 #define MODIFY_SIGNATURE_                                               \
  public:                                                                \
-  virtual void Modify(const char* in, size_t inlen,                     \
+  void Modify(const char* in, size_t inlen,                             \
                       const PerExpandData*, ExpandEmitter* outbuf,      \
-                      const std::string& arg) const
+                      const std::string& arg) const override
 
 // If you wish to write your own modifier, it should subclass this
 // method.  Your subclass should only define Modify(); for efficiency,

--- a/src/template.cc
+++ b/src/template.cc
@@ -935,7 +935,7 @@ class TextTemplateNode : public TemplateNode {
     VLOG(2) << "Constructing TextTemplateNode: "
             << string(token_.text, token_.textlen) << endl;
   }
-  virtual ~TextTemplateNode() {
+  ~TextTemplateNode() override {
     VLOG(2) << "Deleting TextTemplateNode: "
             << string(token_.text, token_.textlen) << endl;
   }
@@ -943,22 +943,22 @@ class TextTemplateNode : public TemplateNode {
   // Expands the text node by simply outputting the text string. This
   // virtual method does not use TemplateDictionaryInterface or PerExpandData.
   // Returns true iff all the template files load and parse correctly.
-  virtual bool Expand(ExpandEmitter *output_buffer,
-                      const TemplateDictionaryInterface *,
-                      PerExpandData *,
-                      const TemplateCache *) const {
+  bool Expand(ExpandEmitter *output_buffer,
+              const TemplateDictionaryInterface *,
+              PerExpandData *,
+              const TemplateCache *) const override {
     output_buffer->Emit(token_.text, token_.textlen);
     return true;
   }
 
   // A noop for text nodes
-  virtual void WriteHeaderEntries(string *outstring,
-                                  const string& filename) const {
+  void WriteHeaderEntries(string *outstring,
+                          const string& filename) const override {
     return;
   }
 
   // Appends a representation of the text node to a string.
-  virtual void DumpToString(int level, string *out) const {
+  void DumpToString(int level, string *out) const override {
     assert(out);
     AppendTokenWithIndent(level, out, "Text Node: -->|", token_, "|<--\n");
   }
@@ -983,7 +983,7 @@ class VariableTemplateNode : public TemplateNode {
     VLOG(2) << "Constructing VariableTemplateNode: "
             << string(token_.text, token_.textlen) << endl;
   }
-  virtual ~VariableTemplateNode() {
+  ~VariableTemplateNode() override {
     VLOG(2) << "Deleting VariableTemplateNode: "
             << string(token_.text, token_.textlen) << endl;
   }
@@ -991,13 +991,13 @@ class VariableTemplateNode : public TemplateNode {
   // Expands the variable node by outputting the value (if there is one)
   // of the node variable which is retrieved from the dictionary
   // Returns true iff all the template files load and parse correctly.
-  virtual bool Expand(ExpandEmitter *output_buffer,
-                      const TemplateDictionaryInterface *dictionary,
-                      PerExpandData *per_expand_data,
-                      const TemplateCache *cache) const;
+  bool Expand(ExpandEmitter *output_buffer,
+              const TemplateDictionaryInterface *dictionary,
+              PerExpandData *per_expand_data,
+              const TemplateCache *cache) const override;
 
-  virtual void WriteHeaderEntries(string *outstring,
-                                  const string& filename) const {
+  void WriteHeaderEntries(string *outstring,
+                          const string& filename) const override {
     WriteOneHeaderEntry(outstring, string(token_.text, token_.textlen),
                         filename);
   }
@@ -1005,7 +1005,7 @@ class VariableTemplateNode : public TemplateNode {
   // Appends a representation of the variable node to a string. We
   // also append the modifiers for that variable in the form:
   // :modifier1[=val1][:modifier2][=val2]...\n
-  virtual void DumpToString(int level, string *out) const {
+  void DumpToString(int level, string *out) const override {
     assert(out);
     AppendTokenWithIndent(level, out, "Variable Node: ", token_,
                           PrettyPrintTokenModifiers(token_.modvals) + "\n");
@@ -1055,26 +1055,26 @@ class PragmaTemplateNode : public TemplateNode {
     VLOG(2) << "Constructing PragmaTemplateNode: "
             << string(token_.text, token_.textlen) << endl;
   }
-  virtual ~PragmaTemplateNode() {
+  ~PragmaTemplateNode() override {
     VLOG(2) << "Deleting PragmaTemplateNode: "
             << string(token_.text, token_.textlen) << endl;
   }
 
   // A no-op for pragma nodes.
-  virtual bool Expand(ExpandEmitter *output_buffer,
-                      const TemplateDictionaryInterface *,
-                      PerExpandData *,
-                      const TemplateCache *) const {
+  bool Expand(ExpandEmitter *output_buffer,
+              const TemplateDictionaryInterface *,
+              PerExpandData *,
+              const TemplateCache *) const override {
     return true;
   };
 
   // A no-op for pragma nodes.
-  virtual void WriteHeaderEntries(string *outstring,
-                                  const string& filename) const { }
+  void WriteHeaderEntries(string *outstring,
+                          const string& filename) const override { }
 
   // Appends a representation of the pragma node to a string. We output
   // the full text given in {{%...}} verbatim.
-  virtual void DumpToString(int level, string *out) const {
+  void DumpToString(int level, string *out) const override {
     assert(out);
     AppendTokenWithIndent(level, out, "Pragma Node: -->|", token_, "|<--\n");
   }
@@ -1131,18 +1131,18 @@ class TemplateTemplateNode : public TemplateNode {
   // and then outputting this newly expanded template in place of the
   // original variable.
   // Returns true iff all the template files load and parse correctly.
-  virtual bool Expand(ExpandEmitter *output_buffer,
-                      const TemplateDictionaryInterface *dictionary,
-                      PerExpandData *per_expand_data,
-                      const TemplateCache *cache) const;
+  bool Expand(ExpandEmitter *output_buffer,
+              const TemplateDictionaryInterface *dictionary,
+              PerExpandData *per_expand_data,
+              const TemplateCache *cache) const override;
 
-  virtual void WriteHeaderEntries(string *outstring,
-                                  const string& filename) const {
+  void WriteHeaderEntries(string *outstring,
+                          const string& filename) const override {
     WriteOneHeaderEntry(outstring, string(token_.text, token_.textlen),
                         filename);
   }
 
-  virtual void DumpToString(int level, string *out) const {
+  void DumpToString(int level, string *out) const override {
     assert(out);
     AppendTokenWithIndent(level, out, "Template Node: ", token_, "\n");
   }
@@ -1285,7 +1285,7 @@ bool TemplateTemplateNode::ExpandOnce(
 class SectionTemplateNode : public TemplateNode {
  public:
   SectionTemplateNode(const TemplateToken& token, bool hidden_by_default);
-  virtual ~SectionTemplateNode();
+  ~SectionTemplateNode() override;
 
   // The highest level parsing method. Reads a single token from the
   // input -- taken from my_template->parse_state_ -- and adds the
@@ -1313,17 +1313,17 @@ class SectionTemplateNode : public TemplateNode {
   //     allowing the section template syntax to be used for both conditional
   //     and iterative text).
   // Returns true iff all the template files load and parse correctly.
-  virtual bool Expand(ExpandEmitter *output_buffer,
-                      const TemplateDictionaryInterface *dictionary,
-                      PerExpandData* per_expand_data,
-                      const TemplateCache *cache) const;
+  bool Expand(ExpandEmitter *output_buffer,
+              const TemplateDictionaryInterface *dictionary,
+              PerExpandData* per_expand_data,
+              const TemplateCache *cache) const override;
 
   // Writes a header entry for the section name and calls the same
   // method on all the nodes in the section
-  virtual void WriteHeaderEntries(string *outstring,
-                                  const string& filename) const;
+  void WriteHeaderEntries(string *outstring,
+                          const string& filename) const override;
 
-  virtual void DumpToString(int level, string *out) const;
+  void DumpToString(int level, string *out) const override;
 
  private:
   const TemplateToken token_;   // text is the name of the section

--- a/src/template_modifiers.cc
+++ b/src/template_modifiers.cc
@@ -401,9 +401,9 @@ CleanseCss cleanse_css;
 // (validate_url_and_css_escape) and is not directly exposed.
 class CssUrlEscape : public TemplateModifier {
  public:
-  virtual void Modify(const char* in, size_t inlen,
-                      const PerExpandData*, ExpandEmitter* outbuf,
-                      const string& arg) const;
+  void Modify(const char* in, size_t inlen,
+              const PerExpandData*, ExpandEmitter* outbuf,
+              const string& arg) const override;
 };
 
 // URL-encodes the characters [\n\r\\'"()<>*] to ensure the URL can be safely

--- a/src/tests/template_dictionary_unittest.cc
+++ b/src/tests/template_dictionary_unittest.cc
@@ -74,7 +74,7 @@ class FooEscaper : public ctemplate::TemplateModifier {
  public:
   void Modify(const char* in, size_t inlen,
               const PerExpandData*,
-              ExpandEmitter* outbuf, const string& arg) const {
+              ExpandEmitter* outbuf, const string& arg) const override {
     assert(arg.empty());    // we don't take an argument
     outbuf->Emit("foo");
   }
@@ -85,7 +85,7 @@ class NullEscaper : public ctemplate::TemplateModifier {
  public:
   void Modify(const char* in, size_t inlen,
               const PerExpandData*,
-              ExpandEmitter* outbuf, const string& arg) const {
+              ExpandEmitter* outbuf, const string& arg) const override {
     assert(arg.empty());    // we don't take an argument
   }
 };
@@ -95,7 +95,7 @@ class DoubleEscaper : public ctemplate::TemplateModifier {
  public:
   void Modify(const char* in, size_t inlen,
               const PerExpandData* data,
-              ExpandEmitter* outbuf, const string& arg) const {
+              ExpandEmitter* outbuf, const string& arg) const override {
     assert(arg.empty());    // we don't take an argument
     string tmp = ctemplate::javascript_escape(in, inlen);
     ctemplate::html_escape.Modify(tmp.data(), tmp.size(), data, outbuf, "");

--- a/src/tests/template_unittest.cc
+++ b/src/tests/template_unittest.cc
@@ -178,11 +178,11 @@ bool IntEqVerbose(int a, int b) {
 class SizeofEmitter : public ExpandEmitter {
   string* const outbuf_;
  public:
-  SizeofEmitter(string* outbuf) : outbuf_(outbuf) {}
-  virtual void Emit(char c) { Emit(&c, 1); }
-  virtual void Emit(const string& s) { Emit(s.data(), s.length()); }
-  virtual void Emit(const char* s) { Emit(s, strlen(s)); }
-  virtual void Emit(const char*, size_t slen) { outbuf_->append(slen, 'X'); }
+  explicit SizeofEmitter(string* outbuf) : outbuf_(outbuf) {}
+  void Emit(char c) override { Emit(&c, 1); }
+  void Emit(const string& s) override { Emit(s.data(), s.length()); }
+  void Emit(const char* s) override { Emit(s, strlen(s)); }
+  void Emit(const char*, size_t slen) override { outbuf_->append(slen, 'X'); }
 };
 
 }  // unnamed namespace
@@ -274,7 +274,7 @@ class DynamicModifier : public ctemplate::TemplateModifier {
  public:
   void Modify(const char* in, size_t inlen,
               const PerExpandData* per_expand_data,
-              ExpandEmitter* outbuf, const string& arg) const {
+              ExpandEmitter* outbuf, const string& arg) const override {
     assert(arg.empty());    // we don't take an argument
     assert(per_expand_data);
     const char* value = per_expand_data->LookupForModifiersAsString("value");
@@ -290,13 +290,13 @@ class EmphasizeTemplateModifier : public ctemplate::TemplateModifier {
   }
 
   bool MightModify(const PerExpandData* per_expand_data,
-                   const string& arg) const {
+                   const string& arg) const override {
     return strstr(arg.c_str(), match_.c_str()) != NULL;
   }
 
   void Modify(const char* in, size_t inlen,
               const PerExpandData* per_expand_data,
-              ExpandEmitter* outbuf, const string& arg) const {
+              ExpandEmitter* outbuf, const string& arg) const override {
     outbuf->Emit(">>");
     outbuf->Emit(in, inlen);
     outbuf->Emit("<<");
@@ -315,40 +315,40 @@ class CustomTestAnnotator : public ctemplate::TextTemplateAnnotator {
   CustomTestAnnotator() : event_count_(0) { }
   void Reset() { event_count_ = 0; }
 
-  virtual void EmitOpenInclude(ExpandEmitter* emitter, const string& value) {
+  void EmitOpenInclude(ExpandEmitter* emitter, const string& value) override {
     EmitTestPrefix(emitter);
     ctemplate::TextTemplateAnnotator::EmitOpenInclude(emitter, value);
   }
-  virtual void EmitCloseInclude(ExpandEmitter* emitter) {
+  void EmitCloseInclude(ExpandEmitter* emitter) override {
     EmitTestPrefix(emitter);
     ctemplate::TextTemplateAnnotator::EmitCloseInclude(emitter);
   }
-  virtual void EmitOpenFile(ExpandEmitter* emitter, const string& value) {
+  void EmitOpenFile(ExpandEmitter* emitter, const string& value) override {
     EmitTestPrefix(emitter);
     ctemplate::TextTemplateAnnotator::EmitOpenFile(emitter, value);
   }
-  virtual void EmitCloseFile(ExpandEmitter* emitter) {
+  void EmitCloseFile(ExpandEmitter* emitter) override {
     EmitTestPrefix(emitter);
     ctemplate::TextTemplateAnnotator::EmitCloseFile(emitter);
   }
-  virtual void EmitOpenSection(ExpandEmitter* emitter, const string& value) {
+  void EmitOpenSection(ExpandEmitter* emitter, const string& value) override {
     EmitTestPrefix(emitter);
     ctemplate::TextTemplateAnnotator::EmitOpenSection(emitter, value);
   }
-  virtual void EmitCloseSection(ExpandEmitter* emitter) {
+  void EmitCloseSection(ExpandEmitter* emitter) override {
     EmitTestPrefix(emitter);
     ctemplate::TextTemplateAnnotator::EmitCloseSection(emitter);
   }
-  virtual void EmitOpenVariable(ExpandEmitter* emitter, const string& value) {
+  void EmitOpenVariable(ExpandEmitter* emitter, const string& value) override {
     EmitTestPrefix(emitter);
     ctemplate::TextTemplateAnnotator::EmitOpenVariable(emitter, value);
   }
-  virtual void EmitCloseVariable(ExpandEmitter* emitter) {
+  void EmitCloseVariable(ExpandEmitter* emitter) override {
     EmitTestPrefix(emitter);
     ctemplate::TextTemplateAnnotator::EmitCloseVariable(emitter);
   }
-  virtual void EmitFileIsMissing(ExpandEmitter* emitter,
-                                    const string& value) {
+  void EmitFileIsMissing(ExpandEmitter* emitter,
+                         const string& value) override {
     EmitTestPrefix(emitter);
     ctemplate::TextTemplateAnnotator::EmitFileIsMissing(emitter, value);
   }


### PR DESCRIPTION
This requires the C++11 `override` keyword; but all major C++ compilers
have defaulted to C++11 or later for quite a while now. (GCC since 2016;
Visual Studio I think since 2012; Clang with a warning since the dawn
of time, and quietly since 2018).

This will make it a lot less noisy to build ctemplate on modern systems.