### PR TITLE
Linter: Fix some const-related issues

### DIFF
--- a/src/ctemplate/find_ptr.h.in
+++ b/src/ctemplate/find_ptr.h.in
@@ -61,14 +61,7 @@ const typename T::value_type::second_type* find_ptr(const T& c, U v)
 }
 
 template <class T, class U>
-typename T::value_type::second_type find_ptr2(T& c, U v)
-{
-  typename T::iterator i = c.find(v);
-  return i == c.end() ? NULL : i->second;
-}
-
-template <class T, class U>
-const typename T::value_type::second_type find_ptr2(const T& c, U v)
+typename T::value_type::second_type find_ptr2(const T& c, U v)
 {
   typename T::const_iterator i = c.find(v);
   return i == c.end() ? NULL : i->second;

--- a/src/ctemplate/template_dictionary.h.in
+++ b/src/ctemplate/template_dictionary.h.in
@@ -115,11 +115,11 @@ class @ac_windows_dllexport@ TemplateDictionary : public TemplateDictionaryInter
       variable_(variable) {
     }
 
-    void operator=(str_ref value) {
+    void operator=(str_ref value) const {
       dict_.SetValue(variable_, TemplateString(value.data(), value.size()));
     }
 
-    void operator=(long value) {
+    void operator=(long value) const {
       dict_.SetIntValue(variable_, value);
     }
 

--- a/src/template.cc
+++ b/src/template.cc
@@ -510,7 +510,7 @@ static TemplateContext GetTemplateContextFromPragma(
 // is traversed.
 // Returns NULL if there is no suitable modifier for that context in
 // which the case the caller is expected to fail the template initialization.
-static const vector<const ModifierAndValue*> GetModifierForContext(
+static vector<const ModifierAndValue*> GetModifierForContext(
     TemplateContext my_context, HtmlParser *htmlparser,
     const Template* my_template) {
   assert(AUTO_ESCAPE_MODE(my_context));


### PR DESCRIPTION
- SetProxy is used as a proxy-reference type, so it should be const-assignable. This fixes -Wassign-to-class-rvalue by hinting to the compiler that it's okay to assign into a prvalue SetProxy: the write will not be lost even though the SetProxy will be destroyed immediately after the write.

- find_ptr2 returns "by const value," which is pointless. In fact the whole second overload of this function is pointless. Eliminate it. This fixes -Wqual-class-return-type.

- GetModifierForContext also returns "by const value." Eliminate the const, thus enabling move semantics for the returned vector. This fixes -Wqual-class-return-type.